### PR TITLE
Please check if these two updates can be merged, thanks

### DIFF
--- a/src/messages/server.rs
+++ b/src/messages/server.rs
@@ -144,6 +144,8 @@ impl Message {
                             check_message_length(length)?;
                             skip(src, length)
                         }
+                        // DesktopSize Pseudo-encoding
+                        -223 => Ok(()),
                         // LastRect Pseudo-encoding
                         -224 => break,
                         // Cursor Pseudo-encoding


### PR DESCRIPTION
1. Fixed issue：unsupported encoding type: -223.
2. Add an optioanl argument "allow", If the value is given, then only the specified ip can connect to rfbproxy.